### PR TITLE
Fix failure to patch on a few records

### DIFF
--- a/BDSPatcher/BDSPatcher.csproj
+++ b/BDSPatcher/BDSPatcher.csproj
@@ -3,7 +3,7 @@
     <OutputType>Exe</OutputType>
     <TargetFramework>net5.0-windows7.0</TargetFramework>
     <TargetPlatformIdentifier>Windows</TargetPlatformIdentifier>
-    <Version>1.4.0</Version>
+    <Version>1.5.0</Version>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">
     <PlatformTarget>x64</PlatformTarget>

--- a/BDSPatcher/BDSPatcher.csproj
+++ b/BDSPatcher/BDSPatcher.csproj
@@ -13,9 +13,9 @@
   </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="Mutagen.Bethesda" Version="0.30.2" />
+        <PackageReference Include="Mutagen.Bethesda" Version="0.30.4" />
         <PackageReference Include="Mutagen.Bethesda.FormKeys.SkyrimSE" Version="2.1.0" />
-        <PackageReference Include="Mutagen.Bethesda.Synthesis" Version="0.19.1" />
+        <PackageReference Include="Mutagen.Bethesda.Synthesis" Version="0.19.2" />
     </ItemGroup>
 
 </Project>

--- a/BDSPatcher/Program.cs
+++ b/BDSPatcher/Program.cs
@@ -148,7 +148,8 @@ namespace BDSPatcher
                 }
                 if (!updated)
                 {
-                    if (!skipMods.Contains(trueTarget.FormKey.ModKey))
+                    // if BDS v2 updates this record, we always patch it. Otherwise, trust game files if this is a record from there.
+                    if (bdsMod.Mod.Statics.ContainsKey(trueTarget.FormKey) || !skipMods.Contains(trueTarget.FormKey.ModKey))
                     {
                         var matName = trueTarget.Material;
                         Console.WriteLine("MATO {0:X8} mapped to BDS {1:X8} in STAT {2}:{3}/{4:X8}",


### PR DESCRIPTION
regression from prior logic to favour record values where "skipped mods" are masters - refine to not do this if BDS.ESP is the patching mod